### PR TITLE
Updated to compile on 7.10

### DIFF
--- a/homework/7/Editor.hs
+++ b/homework/7/Editor.hs
@@ -8,8 +8,10 @@ import System.IO
 import Buffer
 
 import Control.Exception
-import Control.Monad.Trans.State
+import Control.Monad
+-- import Control.Monad.Trans.State
 import Control.Monad.IO.Class
+import Control.Monad.State
 
 import Control.Applicative
 import Control.Arrow       (first, second)
@@ -36,7 +38,7 @@ commands = map show [View, Edit, Next, Prev, Quit]
 -- Editor monad
 
 newtype Editor b a = Editor (StateT (b,Int) IO a)
-  deriving (Functor, Monad, MonadIO, MonadState (b,Int))
+  deriving (Applicative, Functor, Monad, MonadIO, MonadState (b,Int))
 
 runEditor :: Buffer b => Editor b a -> b -> IO a
 runEditor (Editor e) b = evalStateT e (b,0)


### PR DESCRIPTION
There are two changes here.

1. `MonadState` moved to the `mtl` package. http://hackage.haskell.org/package/mtl-2.2.1/docs/Control-Monad-State-Lazy.html As a result, you'll need to `brew install cabal-install && cabal update && cabal install 'mtl == 2.2.1'`

2. `Applicative` is now a superclass of `Monad`. In your case it just means that in order to derive `Monad` for a type, you also have to derive `Applicative`.